### PR TITLE
Fix wrap code snippet tabs on smaller screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -27,6 +27,7 @@
 
 .api-code-tab-group {
   display: flex;
+  flex-wrap: wrap;
 }
 
 .api-code-tab { 


### PR DESCRIPTION
This PR adds a `flex-wrap` property to API code tab groups to prevent their items from overflowing their container on narrower screens.

## Before
<img width="784" alt="Screenshot 2023-09-17 at 18 26 00" src="https://github.com/5e-bits/docs/assets/6972523/f675146b-704d-4b42-ad65-7dc8298dd270">

## After
<img width="777" alt="Screenshot 2023-09-17 at 18 28 30" src="https://github.com/5e-bits/docs/assets/6972523/7ab83ed0-b21c-433c-87fd-a1e92544abfc">
