### PR TITLE
feat: getting started supports powershell and curl for windows or unix

### DIFF
--- a/docs/tutorials/beginner/getting-started.mdx
+++ b/docs/tutorials/beginner/getting-started.mdx
@@ -19,7 +19,7 @@ For example, if you paste and run this terminal command:
 <Tabs queryString="os">
 <TabItem value="unix" label="cURL">
 
-```bash title="ability-score.sh"
+```bash
 curl -X GET "https://www.dnd5eapi.co/api/ability-scores/cha" -H "Accept: application/json"
 
 # or with httpie
@@ -29,7 +29,7 @@ http dnd5eapi.co/api/ability-scores/cha
 </TabItem>
 <TabItem value="win" label="PowerShell">
 
-```powershell title="powershell"
+```powershell
 Invoke-RestMethod -Uri https://www.dnd5eapi.co/api/ability-scores/cha
 ```
 

--- a/docs/tutorials/beginner/getting-started.mdx
+++ b/docs/tutorials/beginner/getting-started.mdx
@@ -2,22 +2,41 @@
 sidebar_position: 1
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 # Getting Started
 
 Let's make our first API request to the D&D 5th Edition API!
 
-Open up a terminal and use [curl](http://curl.haxx.se/) or [httpie](http://httpie.org/)
+Open up a terminal and use [cURL](http://curl.haxx.se/), [PowerShell](https://learn.microsoft.com/en-us/powershell/), or [httpie](http://httpie.org/)
 to make an API request for a resource. You can also scroll through the
 definitions below and send requests directly from the endpoint documentation!
 
-For example, if you paste and run this `curl` command:
+For example, if you paste and run this terminal command:
 
-```bash
+
+<Tabs queryString="os">
+<TabItem value="unix" label="cURL">
+
+```bash title="ability-score.sh"
 curl -X GET "https://www.dnd5eapi.co/api/ability-scores/cha" -H "Accept: application/json"
 
 # or with httpie
 http dnd5eapi.co/api/ability-scores/cha
 ```
+
+</TabItem>
+<TabItem value="win" label="PowerShell">
+
+```powershell title="powershell"
+Invoke-RestMethod -Uri https://www.dnd5eapi.co/api/ability-scores/cha
+```
+
+</TabItem>
+</Tabs>
+
+
 
 We should see a result containing details about the Charisma ability score:
 

--- a/docs/tutorials/beginner/graphql.mdx
+++ b/docs/tutorials/beginner/graphql.mdx
@@ -12,7 +12,7 @@ GraphQL is a powerful and flexible way to fetch data from the D&D 5e SRD API. In
 />
 
 ## From REST to GraphQL
-In the [Getting Started](./getting-started.md) tutorial, we used `curl` to make an HTTP `GET` request to a specific URL that returned the data we wanted. Using that approach, the URL we made a request to corresponded directly to the resource we wanted to fetch; `/api/ability-scores/cha` refers to the resource within the `ability-scores` collection which has the index `cha`.
+In the [Getting Started](./getting-started.mdx) tutorial, we used `curl` to make an HTTP `GET` request to a specific URL that returned the data we wanted. Using that approach, the URL we made a request to corresponded directly to the resource we wanted to fetch; `/api/ability-scores/cha` refers to the resource within the `ability-scores` collection which has the index `cha`.
 
 This is one of the defining features of a RESTful API: a URL corresponds to a resource. The RESTful endpoints of the D&D 5e SRD API follow this uniform interface to make it easy for us to fetch the resources we need, but they don't allow us much control over what data is returned by the API.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -56,6 +56,16 @@ const config = {
           },
         },
         {
+          tabName: "PowerShell",
+          highlight: "powershell",
+          language: "powershell",
+          variant: "RestMethod",
+          options: {
+            followRedirect: true,
+            trimRequestBody: true,
+          },
+        },
+        {
           tabName: "Javascript",
           highlight: "javascript",
           language: "javascript",
@@ -86,6 +96,16 @@ const config = {
           },
         },
         {
+          tabName: "Swift",
+          highlight: "swift",
+          language: "swift",
+          variant: "URLSession",
+          options: {
+            followRedirect: true,
+            trimRequestBody: true,
+          },
+        },
+        {
           tabName: "C#",
           highlight: "csharp",
           language: "csharp",
@@ -101,7 +121,7 @@ const config = {
           language: "java",
           variant: "okhttp",
           options: {
-            followRedirect: true,
+            followRedirect: false,
             trimRequestBody: true,
           },
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -121,7 +121,7 @@ const config = {
           language: "java",
           variant: "okhttp",
           options: {
-            followRedirect: false,
+            followRedirect: true,
             trimRequestBody: true,
           },
         },


### PR DESCRIPTION
## Changes

- Adds powershell/curl tabs to getting started page for more inclusive support of windows and unix users
- Adds Swift to list of API example languages