### PR TITLE
fix: :wrench: duplicated /docs/ url segment

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -4,7 +4,7 @@ sidebar_position: 1
 
 # Introduction
 
-### :arrow_right: [Skip to the tutorials](/docs/docs/tutorials/)
+### :arrow_right: [Skip to the tutorials](/docs/tutorials/)
 
 *If you wanna skip right into the tutorial, go ahead. We don't mind!*
 
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 Welcome to the D&D 5e SRD API, the Dungeons & Dragons 5th Edition API! 
 
-This documentation should help you familiarize yourself with the resources available and how to consume them with HTTP requests. Read through the [Tutorial](/docs/docs/tutorials/) getting started section before you dive in. 
+This documentation should help you familiarize yourself with the resources available and how to consume them with HTTP requests. Read through the [Tutorial](/docs/tutorials/) getting started section before you dive in. 
 
 Most of your problems should be solved just by reading through it.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,6 +29,7 @@ const config = {
       /** @type {import('docusaurus-preset-openapi').Options} */
       ({
         docs: {
+          routeBasePath: '/',
           sidebarPath: require.resolve("./sidebars.js"),
         },
         theme: {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/docs/tutorials/beginner/getting-started"
+            to="/docs/tutorials/beginner/getting-started"
           >
             Get Started - 1min ⏱️
           </Link>


### PR DESCRIPTION
Sets the `docs.routeBasePath` config value of the preset to remove the extra /docs/ segment in URLs.