### PR TITLE
docs: Denote currently supported locales

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -26,7 +26,7 @@ There is a limit of 10,000 requests per second per IP. This is subject to change
 
 ## Multilingual Support
 
-API responses are available in multiple languages. Append `?lang={code}` to any resource request to receive translated content (e.g. `?lang=de` for German). English is always the default and fallback — untranslated fields are returned in English automatically.
+API responses are available in multiple languages. Append `?lang={code}` to any resource request to receive translated content (e.g. `?lang=fr-FR` for French). English is always the default and fallback — untranslated fields are returned in English automatically.
 
 See the [Multilingual Support](./reference/multilingual) reference for the full list of supported languages, response behavior, and how to contribute a translation.
 

--- a/docs/reference/multilingual.md
+++ b/docs/reference/multilingual.md
@@ -8,13 +8,15 @@ The D&D 5e SRD API supports multilingual responses, allowing you to request tran
 
 ## Currently Supported Locales
 
-| Code | Language |
-|---|---|
-| `en` | English (default) |
-| `de` | German |
-| `fr` | French |
+Locale availability differs per ruleset year — the 2014 and 2024 catalogs do not have to ship the same translations.
 
-This list reflects locales with translated content available at the time of writing. The authoritative, always-current list is served by the API itself — query [`/api/{year}/locales`](#list-all-supported-locales) to discover the locales available for a given ruleset year at runtime.
+| Code | Language | 2014 | 2024 |
+|---|---|---|---|
+| `en` | English (default) | Yes | Yes |
+| `fr-FR` | French (France) | Yes | — |
+| `pt-BR` | Portuguese (Brazil) | Yes | Yes |
+
+This table reflects locales with translated content at the time of writing. The authoritative, always-current list is served by the API itself — query [`/api/{year}/locales`](#list-all-supported-locales) to discover the locales available for a given ruleset year at runtime.
 
 ## Requesting a Language
 
@@ -23,7 +25,7 @@ This list reflects locales with translated content available at the time of writ
 Append `?lang={code}` to any resource request. This is the recommended approach because it is explicit and cache-friendly.
 
 ```
-GET /api/2014/spells/acid-arrow?lang=de
+GET /api/2014/spells/acid-arrow?lang=fr-FR
 ```
 
 ### Accept-Language Header
@@ -31,10 +33,10 @@ GET /api/2014/spells/acid-arrow?lang=de
 The `Accept-Language` request header is also supported per [RFC 5646](https://www.rfc-editor.org/rfc/rfc5646). If both a `lang` query parameter and an `Accept-Language` header are present, the query parameter takes precedence.
 
 ```
-Accept-Language: de
+Accept-Language: fr-FR
 ```
 
-Language codes follow the [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) standard (e.g. `de`, `fr`, `pt-BR`).
+Language codes follow the [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) standard (e.g. `fr-FR`, `pt-BR`).
 
 ## Response Behavior
 
@@ -75,8 +77,8 @@ Returns all languages that have at least some translated content for the given r
 {
   "count": 2,
   "results": [
-    { "lang": "de", "url": "/api/2014/locales/de" },
-    { "lang": "fr", "url": "/api/2014/locales/fr" }
+    { "lang": "fr-FR", "url": "/api/2014/locales/fr-FR" },
+    { "lang": "pt-BR", "url": "/api/2014/locales/pt-BR" }
   ]
 }
 ```
@@ -91,8 +93,8 @@ Returns `404` if no translations exist for the requested language.
 
 ```json
 {
-  "lang": "de",
-  "url": "/api/2014/locales/de"
+  "lang": "fr-FR",
+  "url": "/api/2014/locales/fr-FR"
 }
 ```
 
@@ -102,7 +104,7 @@ The optional `lang` argument is available on entity queries:
 
 ```graphql
 query {
-  spell(index: "acid-arrow", lang: "de") {
+  spell(index: "acid-arrow", lang: "fr-FR") {
     name
     desc
   }
@@ -120,18 +122,18 @@ Translations are entirely community-driven. No database access or special toolin
 3. Include only the translatable fields for each entry — non-translatable fields are sourced from the English base automatically
 4. Open a PR — CI validates your translation against the English source
 
-**Example — German spell translation entry:**
+**Example — French spell translation entry:**
 
 ```json
 [
   {
     "index": "acid-arrow",
-    "name": "Säurepfeil",
+    "name": "Flèche acide",
     "desc": [
-      "Ein glitzernder grüner Pfeil schießt auf ein Ziel..."
+      "Une flèche verte scintillante jaillit vers une cible..."
     ],
     "higher_level": [
-      "Wenn du diesen Zauber mit einem Zauberplatz der 3. Stufe oder höher wirkst..."
+      "Lorsque vous lancez ce sort avec un emplacement de sort de niveau 3 ou supérieur..."
     ]
   }
 ]

--- a/docs/reference/multilingual.md
+++ b/docs/reference/multilingual.md
@@ -6,6 +6,16 @@ sidebar_position: 1
 
 The D&D 5e SRD API supports multilingual responses, allowing you to request translated content in supported languages. English is always the default and fallback — if a translation is incomplete or unavailable, fields fall back to English individually, so responses are always complete documents.
 
+## Currently Supported Locales
+
+| Code | Language |
+|---|---|
+| `en` | English (default) |
+| `de` | German |
+| `fr` | French |
+
+This list reflects locales with translated content available at the time of writing. The authoritative, always-current list is served by the API itself — query [`/api/{year}/locales`](#list-all-supported-locales) to discover the locales available for a given ruleset year at runtime.
+
 ## Requesting a Language
 
 ### Query Parameter (recommended)

--- a/versioned_docs/version-2014/introduction.md
+++ b/versioned_docs/version-2014/introduction.md
@@ -26,7 +26,7 @@ There is a limit of 10,000 requests per second per IP. This is subject to change
 
 ## Multilingual Support
 
-API responses are available in multiple languages. Append `?lang={code}` to any resource request to receive translated content (e.g. `?lang=de` for German). English is always the default and fallback — untranslated fields are returned in English automatically.
+API responses are available in multiple languages. Append `?lang={code}` to any resource request to receive translated content (e.g. `?lang=fr-FR` for French). English is always the default and fallback — untranslated fields are returned in English automatically.
 
 See the [Multilingual Support](./reference/multilingual) reference for the full list of supported languages, response behavior, and how to contribute a translation.
 

--- a/versioned_docs/version-2014/reference/multilingual.md
+++ b/versioned_docs/version-2014/reference/multilingual.md
@@ -6,6 +6,16 @@ sidebar_position: 1
 
 The D&D 5e SRD API supports multilingual responses, allowing you to request translated content in supported languages. English is always the default and fallback — if a translation is incomplete or unavailable, fields fall back to English individually, so responses are always complete documents.
 
+## Currently Supported Locales
+
+| Code    | Language            |
+| ------- | ------------------- |
+| `en`    | English (default)   |
+| `fr-FR` | French (France)     |
+| `pt-BR` | Portuguese (Brazil) |
+
+This table reflects locales available for the 2014 ruleset at the time of writing. The authoritative, always-current list is served by the API itself — query [`/api/2014/locales`](#list-all-supported-locales) to discover available locales at runtime.
+
 ## Requesting a Language
 
 ### Query Parameter (recommended)
@@ -13,7 +23,7 @@ The D&D 5e SRD API supports multilingual responses, allowing you to request tran
 Append `?lang={code}` to any resource request. This is the recommended approach because it is explicit and cache-friendly.
 
 ```
-GET /api/2014/spells/acid-arrow?lang=de
+GET /api/2014/spells/acid-arrow?lang=fr-FR
 ```
 
 ### Accept-Language Header
@@ -21,10 +31,10 @@ GET /api/2014/spells/acid-arrow?lang=de
 The `Accept-Language` request header is also supported per [RFC 5646](https://www.rfc-editor.org/rfc/rfc5646). If both a `lang` query parameter and an `Accept-Language` header are present, the query parameter takes precedence.
 
 ```
-Accept-Language: de
+Accept-Language: fr-FR
 ```
 
-Language codes follow the [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) standard (e.g. `de`, `fr`, `pt-BR`).
+Language codes follow the [BCP 47](https://www.rfc-editor.org/rfc/rfc5646) standard (e.g. `fr-FR`, `pt-BR`).
 
 ## Response Behavior
 
@@ -65,8 +75,8 @@ Returns all languages that have at least some translated content for the given r
 {
   "count": 2,
   "results": [
-    { "lang": "de", "url": "/api/2014/locales/de" },
-    { "lang": "fr", "url": "/api/2014/locales/fr" }
+    { "lang": "fr-FR", "url": "/api/2014/locales/fr-FR" },
+    { "lang": "pt-BR", "url": "/api/2014/locales/pt-BR" }
   ]
 }
 ```
@@ -81,8 +91,8 @@ Returns `404` if no translations exist for the requested language.
 
 ```json
 {
-  "lang": "de",
-  "url": "/api/2014/locales/de"
+  "lang": "fr-FR",
+  "url": "/api/2014/locales/fr-FR"
 }
 ```
 
@@ -92,7 +102,7 @@ The optional `lang` argument is available on entity queries:
 
 ```graphql
 query {
-  spell(index: "acid-arrow", lang: "de") {
+  spell(index: "acid-arrow", lang: "fr-FR") {
     name
     desc
   }
@@ -110,15 +120,15 @@ Translations are entirely community-driven. No database access or special toolin
 3. Include only the translatable fields for each entry — non-translatable fields are sourced from the English base automatically
 4. Open a PR — CI validates your translation against the English source
 
-**Example — German spell translation entry:**
+**Example — French spell translation entry:**
 
 ```json
 [
   {
     "index": "acid-arrow",
-    "name": "Säurepfeil",
+    "name": "Flèche acide",
     "desc": [
-      "Ein schimmernder grüner Pfeil schießt auf ein Ziel in Reichweite ..."
+      "Une flèche verte scintillante jaillit vers une cible à portée ..."
     ]
   }
 ]


### PR DESCRIPTION
## Summary

- Add a "Currently Supported Locales" section to the multilingual support reference, listing the locales actually served by the API (`en`, `fr-FR`, `pt-BR`) with per-ruleset availability (2014 ships `fr-FR` + `pt-BR`; 2024 ships `pt-BR` only).
- Point readers at `/api/{year}/locales` as the authoritative runtime source for the current list.
- Replace the illustrative `de`/`fr` codes used throughout the multilingual reference and introduction (query string, `Accept-Language` header, `/locales` example response, GraphQL query, and the contributing-translation example) with real, currently-supported locale codes so the example payloads match what the API actually returns.
- Mirror the same fixes into the `version-2014` versioned copies of `introduction.md` and `reference/multilingual.md`.

Locales were verified against the [`5e-bits/5e-database`](https://github.com/5e-bits/5e-database) source tree under `src/2014/` and `src/2024/`.

## Test plan

- [ ] Build the docs site and confirm the new "Currently Supported Locales" table renders, the `#list-all-supported-locales` anchor link resolves, and no broken-link warnings appear.
- [ ] Spot-check that the 2014 reference and the `version-2014` reference render consistently.